### PR TITLE
[INV-15] Fixed /server/sassCheck.sh cloning sass to the wrong directory

### DIFF
--- a/server/sassCheck.sh
+++ b/server/sassCheck.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+set -e
+
+sass_dir="$BASE_DIR/server/sass"
+
 #DL sass
-if [ ! -f ./sass/dart-sass/sass ]; then
-    mkdir -p ./sass/
-    curl -L https://github.com/sass/dart-sass/releases/download/1.22.3/dart-sass-1.22.3-linux-x64.tar.gz > ./sass/sass.tar.gz
-    cd ./sass
+if [ ! -f "$sass_dir/dart-sass/sass" ]; then
+    mkdir -p "$sass_dir"
+    curl -L https://github.com/sass/dart-sass/releases/download/1.22.3/dart-sass-1.22.3-linux-x64.tar.gz > $sass_dir/sass.tar.gz
+    cd "$sass_dir"
     tar -xzvf ./sass.tar.gz
     rm ./sass.tar.gz
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export BASE_DIR=$(pwd)
+
 ./server/sassCheck.sh
 
 python3 -m venv venv --system-site-packages
@@ -7,3 +9,4 @@ python3 -m venv venv --system-site-packages
 . venv/bin/activate
 
 pip install Flask requests flask_sqlalchemy psycopg2
+


### PR DESCRIPTION
- Exported a new ENV variable called BASE_DIR that is the base project
dir.
- server/sassCheck.sh uses BASE_DIR to clone sass to the correct
directory.